### PR TITLE
:sparkles: Adding Slides Content GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-slides-content-template.md
+++ b/.github/ISSUE_TEMPLATE/new-slides-content-template.md
@@ -1,0 +1,24 @@
+---
+name: New slides content template
+about: scaffold for new slides content
+title: "\U0001F5B9 [slides] - "
+labels: slides
+assignees: ''
+
+---
+
+### <Name of the Slides Content>
+* Module: <NAME>
+
+### 📝 Description
+...description of the slides content or practice
+
+### 🥤 Additional Info 
+...link to the docs where the slides content should be added or links to blogs etc that form the basis of the content.
+
+### ✅ A/Cs
+- [ ] Content
+- [ ] Facilitator notes updated (if applicable)
+- [ ] Slides content peer reviewed with one other region member
+- [ ] Content loop image updated (if applicable)
+- [ ] Slides content linked in content loop image


### PR DESCRIPTION
GitHub Issue template for Slides Content

It could help to create new issues related with the content of the slides, and practices.

For example: to create issues related with some of the practices in content loop without content created.