### PR TITLE
Fix issue with printf and passwords with `%`

### DIFF
--- a/docs/1-the-manual-menace/3-ubiquitous-journey.md
+++ b/docs/1-the-manual-menace/3-ubiquitous-journey.md
@@ -112,8 +112,8 @@ All of these traits lead to one outcome - the ability to build and release quali
     cat <<EOF | oc apply -n ${TEAM_NAME}-ci-cd -f -
       apiVersion: v1
       data:
-        password: "$(printf ${GITLAB_PASSWORD} | base64 -w0)"
-        username: "$(printf ${GITLAB_USER} | base64 -w0)"
+        password: "$(echo -n ${GITLAB_PASSWORD} | base64 -w0)"
+        username: "$(echo -n ${GITLAB_USER} | base64 -w0)"
       kind: Secret
       metadata:
         annotations:


### PR DESCRIPTION
```
$ cat <<EOF >foo
>   apiVersion: v1
>   data:
>     password: "$(printf ${GITLAB_PASSWORD} | base64 -w0)"
>     username: "$(printf ${GITLAB_USER} | base64 -w0)"
>   kind: Secret
>   metadata:
>     annotations:
>       tekton.dev/git-0: https://${GIT_SERVER}
>     labels:
>       credential.sync.jenkins.openshift.io: "true"
>     name: git-auth
> EOF
```

Produces:

```
sh: printf: `S': invalid format character                        
```

then...

```
$ cat foo
  apiVersion: v1
  data:
    password: "....U1A6d2g/a0w="
    username: "YWxleGNvcmNvbGVz"
  kind: Secret
  metadata:
    annotations:
      tekton.dev/git-0: https://gitlab-ce.apps.tl500-1.ls-eu.ole.redhat.com/
    labels:
      credential.sync.jenkins.openshift.io: "true"
    name: git-auth
$ echo ...U1A6d2g/a0w= | base64 -d ; echo
....SP:wh?kL
$ echo $GITLAB_PASSWORD
...SP:wh?kL%S
```

Using `echo -n`:

```
$ cat <<EOF >foo
>   apiVersion: v1
>   data:
>     password: "$(echo -n ${GITLAB_PASSWORD} | base64 -w0)"
>     username: "$(echo -n ${GITLAB_USER} | base64 -w0)"
>   kind: Secret
>   metadata:
>     annotations:
>       tekton.dev/git-0: https://${GIT_SERVER}
>     labels:
>       credential.sync.jenkins.openshift.io: "true"
>     name: git-auth
> EOF
$ cat foo
  apiVersion: v1
  data:
    password: "...6d2g/a0wlUw=="
    username: "YWxleGNvcmNvbGVz"
  kind: Secret
  metadata:
    annotations:
      tekton.dev/git-0: https://gitlab-ce.apps.tl500-1.ls-eu.ole.redhat.com/
    labels:
      credential.sync.jenkins.openshift.io: "true"
    name: git-auth
$ echo WDA6dE84U1A6d2g/a0wlUw== | base64 -d ; echo
....SP:wh?kL%S
$ echo $GITLAB_PASSWORD
...SP:wh?kL%S
```