### PR TITLE
Fix UI item needed to access Jenkins credentials

### DIFF
--- a/docs/2-attack-of-the-pipelines/1-sealed-secrets.md
+++ b/docs/2-attack-of-the-pipelines/1-sealed-secrets.md
@@ -137,7 +137,7 @@ git pull
 9. You may need to force sync your secret in argocd to get it to apply:
 ![argocd-force-sync.png](images/argocd-force-sync.png)
 
-    🪄 You can verify it's been synced to Jenkins now by opening `Jenkins -> Configuration -> Credentials` to view `<TEAM_NAME>-ci-cd-git-auth` credential is there
+    🪄 You can verify it's been synced to Jenkins now by opening `Jenkins -> Manage Jenkins -> Manage Credentials` to view `<TEAM_NAME>-ci-cd-git-auth` credential is there
 
     ```bash
     echo https://$(oc get route jenkins --template='{{ .spec.host }}' -n ${TEAM_NAME}-ci-cd)


### PR DESCRIPTION
There is no "configure" button on the Jenkins home page that I can see, but "Manage Jenkins" is clearly visible.

![image](https://user-images.githubusercontent.com/1150630/146180131-e63835f5-2d44-4472-9b2c-dc74dc1f3ebc.png)

and

![image](https://user-images.githubusercontent.com/1150630/146180744-7b98066d-9d18-4042-808f-a044c82475a5.png)
