### PR TITLE
Remove extraneous \n in echo

### DIFF
--- a/docs/2-attack-of-the-pipelines/3a-jenkins.md
+++ b/docs/2-attack-of-the-pipelines/3a-jenkins.md
@@ -47,7 +47,7 @@ git push
 3. We want to be able to tell Jenkins to run a build for every code change - welcome our good ol' friend the Webhook. Just like we did with Argo CD earlier, let's add a webhook to GitLab for our Pet Battle front end so every commit triggers it. Jenkins needs a url of the form `<JENKINS_URL>/multibranch-webhook-trigger/invoke?token=<APP_NAME>` to trigger a build:
 
     ```bash
-    echo "\n https://$(oc get route jenkins --template='{{ .spec.host }}' -n ${TEAM_NAME}-ci-cd)/multibranch-webhook-trigger/invoke?token=pet-battle"
+    echo "https://$(oc get route jenkins --template='{{ .spec.host }}' -n ${TEAM_NAME}-ci-cd)/multibranch-webhook-trigger/invoke?token=pet-battle"
     ```
 
     Once you have the URL, over on GitLab go to `pet-battle > Settings > Integrations` to add the webhook 


### PR DESCRIPTION
This is not interpreted by echo, so it prints out something odd.

This could have been originally a `printf`, maybe?