### PR TITLE
Make copy and pasting easier

### DIFF
--- a/docs/3-revenge-of-the-automated-testing/1-sonar-scanning.md
+++ b/docs/3-revenge-of-the-automated-testing/1-sonar-scanning.md
@@ -52,14 +52,14 @@
 3. Open up `ubiquitous-journey/values-tooling.yaml` file and extend the Sealed Secrets entry. Copy the output of `username`, `password` and `currentAdminPassword` from the previous command and update the values. Make sure you indent the data correctly.
 
     ```yaml
-            - name: sonarqube-auth
-              type: Opaque
-              labels:
-                credential.sync.jenkins.openshift.io: "true"
-              data:
-                username: AgAj3JQj+EP23pnzu...
-                password: AgAtnYz8U0AqIIaqYrj...
-                currentAdminPassword: AgCHCphbYpeLYMPK...
+      - name: sonarqube-auth
+        type: Opaque
+        labels:
+          credential.sync.jenkins.openshift.io: "true"
+        data:
+          username: AgAj3JQj+EP23pnzu...
+          password: AgAtnYz8U0AqIIaqYrj...
+          currentAdminPassword: AgCHCphbYpeLYMPK...
       ```
 
     and push the changes:


### PR DESCRIPTION
I think with this change, when using the copy button in the UI, the YAML should line "perfectly" without having to fix indentation.