### PR TITLE
Removes ⚡ escaping slashes⚡ from conventions cos they're not needed 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,10 +22,10 @@ For example if the git server lives at <code class="language-yaml">https://gitla
 put `gitlab-ce.apps.hivec.sandbox1243.opentlc.com`in the box to generate the correct address for the exercises.
 
 ## 🦆 Conventions
-When running through the exercise, we're tried to call out where things need replacing. The key ones are anything inside an `<>` should be replaced. For example, if your team is called `biscuits` then in the instructions if you see `<TEAM_NAME\>` this should be replaced with `biscuits` like so:
+When running through the exercise, we're tried to call out where things need replacing. The key ones are anything inside an `<>` should be replaced. For example, if your team is called `biscuits` then in the instructions if you see `<TEAM_NAME>` this should be replaced with `biscuits` like so:
     <div class="highlight" style="background: #f7f7f7">
     <pre><code class="language-bash">
-    name: <\TEAM_NAME\>
+    name: <TEAM_NAME>
     # ^ this becomes
     name: biscuits
     </code></pre></div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ For example if the git server lives at <code class="language-yaml">https://gitla
 put `gitlab-ce.apps.hivec.sandbox1243.opentlc.com`in the box to generate the correct address for the exercises.
 
 ## 🦆 Conventions
-When running through the exercise, we're tried to call out where things need replacing. The key ones are anything inside an `<>` should be replaced. For example, if your team is called `biscuits` then in the instructions if you see `\<TEAM_NAME\>` this should be replaced with `biscuits` like so:
+When running through the exercise, we're tried to call out where things need replacing. The key ones are anything inside an `<>` should be replaced. For example, if your team is called `biscuits` then in the instructions if you see `<TEAM_NAME\>` this should be replaced with `biscuits` like so:
     <div class="highlight" style="background: #f7f7f7">
     <pre><code class="language-bash">
     name: <\TEAM_NAME\>


### PR DESCRIPTION
The instructions were different to the example which was a bit confusing, so making it consistent in order to avoid common typo errors.