### PR TITLE
Add instructions to exit rsh

### DIFF
--- a/docs/4-return-of-the-monitoring/3-logging.md
+++ b/docs/4-return-of-the-monitoring/3-logging.md
@@ -52,6 +52,7 @@
     echo "🦄🦄🦄🦄" >> /tmp/custom.log
     echo "🦄🦄🦄🦄" >> /tmp/custom.log
     echo "🦄🦄🦄🦄" >> /tmp/custom.log
+    exit
     ```
 
 9. Back on Kibana we can filter and find these messages with another query:


### PR DESCRIPTION
It is not very visible that you are in a subshell (the version of bash changes, but the prompt is *very* similar), so people might be confused if they don't remember to exit.