### PR TITLE
:bug: Fixing DevOps Handbook image link

### DIFF
--- a/docs/slides/content/what-is-devops.md
+++ b/docs/slides/content/what-is-devops.md
@@ -48,7 +48,7 @@ come to mind.
 ### The Three Ways of DevOps
 #### _The DevOps Handbook_
 #### by Gene Kim, et. al.
-![DevOps Handbook](images/devops/devopshandbook.jpg)
+![DevOps Handbook](images/DevOps/devopshandbook.jpg)
 
 
 


### PR DESCRIPTION
Typo in link to DevOps Handbook in "What is DevOps?" content slides.