### PR TITLE
Remove Facilitator note and removed a screenshot

### DIFF
--- a/docs/1-the-manual-menace/1-the-basics.md
+++ b/docs/1-the-manual-menace/1-the-basics.md
@@ -46,7 +46,7 @@
 8. Check if you can connect to OpenShift. Run the command below.
 
     <p class="tip">
-    ⛷️ <b>TIP</b> ⛷️ - Before you hit enter, make sure you change the username and password to match your team's login details
+    ⛷️ <b>TIP</b> ⛷️ - Before you hit enter, make sure you change the username and password to match your team's login details. If your password includes special characters, put it in single quotes. ie: 'A8y?Rpm!9+A3B/KG'
     </p>  
 
     ```bash

--- a/docs/slides/content/tech-exercise-i.md
+++ b/docs/slides/content/tech-exercise-i.md
@@ -87,17 +87,11 @@ _We will set up Git projects, create dev, test, and stage projects in OpenShift,
 
 
 
-### 💥 Mob to Learn 💥
-* Begin with the [pairing and mobbing](?name=pairing-and-mobbing) exercise (if not already completed).
+### 💥 Let's Begin 💥
 * In your table teams, form a mob to complete the exercise. Work together as a team to deploy your shared tooling and infrastructure!
-* Rotate the `driver` at the end of the section to give everyone a chance to get their hands dirty with code!
-* If you finish early, try your hand at the `Here be dragons` section.
-* Your tutor will share links to the instructions, OpenShift Console, CRW, and GitLab server.
-
-
-
-### 💥 CodeReadyWorkspaces 💥 <!-- .element: class="title-bottom-left" -->
-<!-- .slide: data-background-size="contain" data-background-image="images/tech-exercise-i/crw.png", class="white-style" data-background-opacity="1"	 -->
+* You will want to rotate the `driver` at the end of each exercise section to give everyone a chance to get their hands dirty with code!
+* If you finish the exercise early, try your hand at the `Here be dragons` section.
+* Your facilitator will share links to the instructions, OpenShift Console, CRW, and GitLab server.
 
 
 


### PR DESCRIPTION
There is a note about running the Pairing and Mobbing activity if not already done. This is a facilitator note and doesn't need to be in slide ware. The CRW screenshot is in the instructions site and not needed in the slide ware. Once students are logged in, they should follow instructions that are on the exercise instruction site.