### PR TITLE
Update 7-image-security.md

### DIFF
--- a/docs/3-revenge-of-the-automated-testing/7-image-security.md
+++ b/docs/3-revenge-of-the-automated-testing/7-image-security.md
@@ -10,15 +10,17 @@
 
 StackRox / Advanced Cluster Security (ACS) is deployed once at the cluster scope. It can be used to monitor multiple clusters. The ACS/StackRox operator is already deployed and configured in the cluster for you.
 
-1. Connect to the ACS WebUI Route using the **admin** credentials:
+1. Connect to the ACS WebUI Route:
 
     ```bash
     # get web url
     echo https://$(oc -n stackrox get route central --template='{{ .spec.host }}')
     ```
 
+    Using the **admin** username:
+
     ```bash
-    # get credentials
+    # get password to go with the "admin" username:
     echo $(oc -n stackrox get secret central-htpasswd -o go-template='{{index .data "password" | base64decode}}')
     ```
 


### PR DESCRIPTION
Issue #153 is not a bug but a case of unclear documentation. Added wording to not to refer to credentials but to username and password, split the instruction to make it even more explicit.