### PR TITLE
Fix small formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## TL500 Mono Repo
 
 This monorepo holds the content for the TL500 (aka DO500). The structure is roughly as follows 
-```bash
+```
 ...
 ├── README.md
 ├── docs


### PR DESCRIPTION
The word `test` is rendered in blue in bash syntax blocks, this change removes the syntax highlighting.