### PR TITLE
Adding warn boxes regarding git commands

### DIFF
--- a/docs/3-revenge-of-the-automated-testing/6a-jenkins.md
+++ b/docs/3-revenge-of-the-automated-testing/6a-jenkins.md
@@ -20,6 +20,8 @@
     git push
     ```
 
+    <p class="warn">If you get an error like <b>error: failed to push some refs to..</b>, please run <b><i>git pull</i></b>, then push your changes again by running above commands.</p>
+
 2. Open up `/projects/pet-battle/Jenkinsfile` and add the below stage where `// 🐝 OWASP ZAP STAGE GOES HERE` placeholder is, to trigger ZAP scanning against Pet Battle. This stage will create a report on possible security vulnerabilities.
 
     ```groovy

--- a/docs/3-revenge-of-the-automated-testing/9a-jenkins.md
+++ b/docs/3-revenge-of-the-automated-testing/9a-jenkins.md
@@ -31,6 +31,8 @@
     git push
     ```
 
+    <p class="warn">If you get an error like <b>error: failed to push some refs to..</b>, please run <b><i>git pull</i></b>, then push your changes again by running above commands.</p>    
+
 2. We need to create a `locustfile.py` for testing scenario and save it in the application repository.
 
     Below scenario calls `/home` endpoint and fails the test if:


### PR DESCRIPTION
Some git push commands could fail because there are changes in git remote repo (changes created by the pipelines). The user could be confused, so this PR includes a set of extra warn boxes to help in these cases.

