### PR TITLE
pipelines-jenkins docs fix repo to gitlab project

### DIFF
--- a/docs/2-attack-of-the-pipelines/3a-jenkins.md
+++ b/docs/2-attack-of-the-pipelines/3a-jenkins.md
@@ -28,9 +28,9 @@ git push
 ```
 --->
 
-#### Setup Pet Battle (front end) Git Repo
+#### Setup Pet Battle (front end) GitLab Project
 
-1. Open the GitLab UI. Create a repo in GitLab under `<TEAM_NAME>` group called `pet-battle`. Make the project as **public**.
+1. Open the GitLab UI. Create a Project in GitLab under `<TEAM_NAME>` group called `pet-battle`. Make the project as **public**.
 
     ![pet-battle-git-repo](images/pet-battle-git-repo.png)
 


### PR DESCRIPTION
Docs mentined create repo, but it confuses user,
because GitLab terminology uses Project.