### PR TITLE
pipelines-tekton docs fix terminology from repo to gitlab project

### DIFF
--- a/docs/2-attack-of-the-pipelines/3b-tekton.md
+++ b/docs/2-attack-of-the-pipelines/3b-tekton.md
@@ -16,7 +16,7 @@ In this snippet of the pipeline used in this exercise, we define:
 
 #### Deploying the Tekton Objects
 
-1. Open the GitLab UI. Create a repo in GitLab under `<TEAM_NAME>` group called `pet-battle-api`. Make the project as **internal**.
+1. Open the GitLab UI. Create a Project in GitLab under `<TEAM_NAME>` group called `pet-battle-api`. Make the project as **internal**.
 
     ![pet-battle-api-git-repo](images/pet-battle-api-git-repo.png)
 


### PR DESCRIPTION
Docs mentioned create `repo`, but it confuses user,
because GitLab terminology uses `Project`.