### PR TITLE
Adding Contribution guides to extend the community

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,72 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+[rhc-open-innovation-labs@redhat.com](mailto:rhc-open-innovation-labs@redhat.com).
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@
 ## What to contribute
 
 * 🐛 Fixing typos
-👑 exercises
-🖹 content 
+* 👑 Extending or fixing exercises
+* 🖹 Adding or extending slide content
 * 📝 Adding/Updating commands, blocks, texts, ...
 * 👋 Whatever you want to contribute with some value for this repo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contribution Guide
+
+👋 Welcome! 👋
+
+👍🎉 First off, thanks for taking the time to contribute! 🎉👍
+
+## What to contribute
+
+* 🐛 Fixing typos
+👑 exercises
+🖹 content 
+* 📝 Adding/Updating commands, blocks, texts, ...
+* 👋 Whatever you want to contribute with some value for this repo
+
+## Code of Conduct
+
+This project is governed by our [Code of Conduct](./CODE_OF_CONDUCT.md). All participants
+are expected to uphold this code. Violations of the code can be reported by contacting
+us in communication channels.
+
+## How to contribute
+
+Fork the repo, add or change markdown files, and create a pull request. You can make these changes
+via the GitHub web interface, the command line, or a git client of your choice.
+
+Once you create a pull request, we will review for sure, but it might take me some time to comment, review,
+or merge it.
+
+### Before you contribute
+
+To contribute, use GitHub Pull Requests, from your own **fork**.
+
+Also, make sure you have set up your Git authorship correctly:
+
+```shell
+git config --global user.name "Your Full Name"
+git config --global user.email your.email@example.com
+```
+
+We use this information to acknowledge your contributions in release announcements.
+
+### Pull Request Process
+
+To integrate changes into the stable branches of the product must be done by a
+pull request process:
+
+* Create a new branch.
+* Push commits to the branch. (We love emojis 💌, so add one at the beginning to improve the commit.)
+* Consider whether documentation need to be added or updated as part of the change.
+* Open a PR against the target branch of the repository.
+	* If the PR is still a work in progress, and so is not ready to be merged, but needs to be pushed to
+	facilitate review, then add `[WIP]` in the title. Optionally add the labels `work-in-progress` and `do-not-merge`.
+	* Consider identifying committers who have worked on the documentation being changed.
+* Add comments with information about the PR.
+* During The Review Process you could add more commits in the PR.
+* The PR will be approved when:
+	* Content is successful.
+	* A committer reviewed and verified it successfully.
+* Committers have the quality vote to approve or reject the PR.
+* If your PR is rejected, close it.
+* In general the PR will be integrated as one commit (Squash and Merge) to have a cleaner log history. 
+
+### Code reviews
+
+All submissions, including submissions by project members, need to be reviewed before being merged.
+
+* Other reviewers, including committers, may comment on the changes and suggest modifications. Changes can
+be added by simply pushing more commits to the same branch.
+* Please add a comment and "@" the reviewer in the PR if you have addressed reviewers' comments.
+* Any conversation must comply with the [Code of Conduct](./CODE_OF_CONDUCT.md)
+of the community. The outcome may be a rejection of the entire change.
+* Reviewers will typically include the acronym “LGTM” (`Looks Good To Me`) in their approval comment. This is a
+convention defined to approve PR before the “approve” it.
+* Sometimes, other changes will be merged which conflict with your PR's changes. The PR cannot
+be merged until the conflict is resolved. 
+* Try to be responsive to the discussion rather than let days pass between replies.
+
+## Gathering Feedback
+
+As a community, we strive to provide kind and constructive feedback on your PR.
+
+If a pull request doesn't meet the "must be" guidelines, we may ask that the pull request be updated
+before it's merged. If a pull request doesn't meet the "should be" guidelines,
+we may merge the pull request and add an issue for future improvements.
+
+Again, thank you so much for your interest and support!
+
+Happy contributing 📝📚👪!!!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## TL500 Mono Repo
 
-This monorepo holds the content for the TL500 (aka DO500). The structure is roughly as follows 
+This monorepo holds the content for the TL500 (aka DO500). The structure is roughly as follows:
+
 ```
 ...
 ├── README.md
@@ -22,16 +23,20 @@ This monorepo holds the content for the TL500 (aka DO500). The structure is roug
 ├── ubiquitous-journey
     └── ...
 ```
+
 whereby
-* `docs` - contains the student and teacher guides for the technical exercises as well as the classroom activities. The `slides/content` are written in markdown and automatically published to the site when pushed to main.
+
+* `docs` - contains the student and teacher guides for the technical exercises as well as the classroom
+activities. The `slides/content` are written in markdown and automatically published to the site when pushed to main.
 * `pet-battle` - contains the application configs used by the tech exercise
 * `ubiquitous-journey` -  contains a lightweight fork of the rht-labs ci/cd stack
 * `tekton` - contains the OpenShift pipeline definitions used in the tech exercise.
 
-
 ### 🏃‍♀️ Running the docs & slides site locally
+
 To launch the slides, ensure you have NodeJS installed or run it in a NodeJS container if you prefer.
-```
+
+```shell
 npm i -g docsify-cli@4.4.3
 docsify serve ./docs
 ```
@@ -40,6 +45,7 @@ docsify serve ./docs
 * Open the browser to http://localhost:3000/slides to view the slides.
 
 ## 🎃 Contribution
-Pull requests welcome 🎃
 
-Changes approved and pushed to main will automatically be published to the docs site
+Pull requests welcome 🎃. Please 🙏, review 👀 the [Contribution Guide](./CONTRIBUTING.md) to became a contributor.
+
+Changes approved and pushed to main will automatically be published to the docs site.


### PR DESCRIPTION
As we are looking for new contributors, and improve the content (slides, and exercises), we should provide some guidelines for the new contributors.

This PR include an initial version of the standard files in GitHub about:

* Contribution Guide (aka CONTRIBUTING.md file)
* Code of Conduct (aka CODE_OF_CONDUCT.md file)

Maybe this PR could be extended with some tips, comments about best practices or patterns followed in the repo, such as:

* Commit messages
* Emoji use cases

