### PR TITLE
Fixing a typo with the "oc login --server" instruction

### DIFF
--- a/docs/1-the-manual-menace/1-the-basics.md
+++ b/docs/1-the-manual-menace/1-the-basics.md
@@ -50,7 +50,7 @@
     </p>
 
     ```bash
-    oc login --server=https://api.${CLUSTER_DOMAIN##apps.}:6443 -u <USERNAME> -p <PASSWORD>
+    oc login --server=https://api.${CLUSTER_DOMAIN}:6443 -u <USERNAME> -p <PASSWORD>
     ```
 
 9. Check your user permissions in OpenShift by creating your team's `ci-cd` project. 


### PR DESCRIPTION
Small typo during the "CodeReady Workspaces setup" instructions.

**Step 8: Check if you can connect to OpenShift.**
`oc login --server=https://api.${CLUSTER_DOMAIN##apps.}:6443 -u <USERNAME> -p <PASSWORD>`

should be
`oc login --server=https://api.${CLUSTER_DOMAIN}:6443 -u <USERNAME> -p <PASSWORD>`
