### PR TITLE
Adding support for using a variables file to configure runtime values

### DIFF
--- a/docs/1-the-manual-menace/1-the-basics.md
+++ b/docs/1-the-manual-menace/1-the-basics.md
@@ -7,7 +7,7 @@
 
     <p class="warn">
     If the workspace has not been set up for you, you can create one from this devfile. On CodeReady Workspaces, "Create Workspace > Custom Workspace". Enter this URL to load the TL500 stack:</br>
-    <span style="color:blue;"><a href="https://raw.githubusercontent.com/rht-labs/enablement-framework/main/codereadyworkspaces/tl500-devfile.yaml">https://raw.githubusercontent.com/rht-labs/enablement-framework/main/codereadyworkspaces/tl500-devfile.yaml</a><span>
+    <span style="color:blue;"><a href="${devfile_location}">${devfile_location}</a><span>
     </p>
 
 2. In your IDE (it may take some time to open ... ⏰☕️), open a new terminal by hitting `Terminal > Open Terminal in Specific Container > stack-tl500` from the menu.

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
       },
       pagination: {
         crossChapter: true
-    },
+      },
       plugins: [
         function(hook) {
           hook.beforeEach(function(content) {
@@ -125,6 +125,8 @@
         }
       ],
       search: 'auto', // default
+      variablesFile : 'vars/tl500-variables.json',
+      variablesFileType : 'json',
       vueComponents: { }
     }    
   </script>
@@ -135,6 +137,7 @@
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/zoom-image.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
   <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>  
+  <script src="//unpkg.com/docsify-variables/dist/docsify-variables.min.js"></script>
   <script src="//unpkg.com/prismjs/components/prism-bash.min.js"></script>
   <script src="//unpkg.com/prismjs/components/prism-yaml.min.js"></script>
   <script src="//unpkg.com/prismjs/components/prism-groovy.min.js"></script>

--- a/docs/vars/tl500-variables.json
+++ b/docs/vars/tl500-variables.json
@@ -1,0 +1,3 @@
+{
+	"devfile_location": "https://raw.githubusercontent.com/rht-labs/enablement-framework/main/codereadyworkspaces/tl500-devfile.yaml"
+}


### PR DESCRIPTION
First out is the `devfile_location`, which allows for the URL to the CRW devfile to be configured at deployment time. 