### PR TITLE
Make tests environment agnostic

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -11,9 +11,12 @@ We check the command and success return codes (we filter output for now) against
 A `non zero` exit code signifies some tests failed. See the test logs for details.
 
 Testing Requirements:
+
 - A running openshift cluster with tl500 tooling installed to run against
 
-### Running tests in OpenShift
+### Running Tests
+
+#### In OpenShift
 
 The tests can run on OpenShift:
 
@@ -32,7 +35,7 @@ oc -n tech-exercise-test run test-$(date +"%Y-%m-%d-%H-%M-%S") --image=quay.io/e
   --restart=Never
 ```
 
-### Running tests locally
+#### Locally
 
 The tests run in a container on your laptop:
 
@@ -47,7 +50,36 @@ podman run \
   -e "OCP_PASSWORD=${OCP_PASSWORD}" \
   -e "OCP_ADMIN_USER=${OCP_ADMIN_USER}" \
   -e "OCP_ADMIN_PASSWORD=${OCP_ADMIN_PASSWORD}" \
-  quay.io/eformat/tech-exercise-test:latest 
+  quay.io/eformat/tech-exercise-test:latest
+```
+
+#### Specify a Different Repository & Branch
+
+No matter whether you run your tests locally or in an OpenShift cluster, by default they always test
+the repo `https://github.com/rht-labs/tech-exercise.git` and the branch `main`.
+
+Most of the times that is what you would like to run your tests against, but there will be times when
+you would like to test against your own development fork before creating a Pull Request for example, or against
+an specific branch.
+
+You can do that by passing the env vars `REPO` and `BRANCH`, and that would override the default values.
+
+Here it is an example running the test locally against your own repo `https://github.com/myorg/tech-exercises` and branch `hot-fix-415`:
+
+```bash
+podman run \
+  -e "CLUSTER_DOMAIN=${CLUSTER_DOMAIN}" \
+  -e "GIT_SERVER=${GIT_SERVER}" \
+  -e "TEAM_NAME=${TEAM_NAME}" \
+  -e "GITLAB_USER=${GITLAB_USER}" \
+  -e "GITLAB_PASSWORD=${GITLAB_PASSWORD}" \
+  -e "OCP_USER=${OCP_USER}" \
+  -e "OCP_PASSWORD=${OCP_PASSWORD}" \
+  -e "OCP_ADMIN_USER=${OCP_ADMIN_USER}" \
+  -e "OCP_ADMIN_PASSWORD=${OCP_ADMIN_PASSWORD}" \
+  -e "REPO=https://github.com/myorg/tech-exercises" \
+  -e "BRANCH=hot-fix-415" \
+  quay.io/eformat/tech-exercise-test:latest
 ```
 
 ### Test Development
@@ -55,8 +87,8 @@ podman run \
 To run testing locally for development:
 
 ```bash
-podman pull quay.io/rht-labs/stack-tl500:3.0.14
-podman run -d --name stack quay.io/rht-labs/stack-tl500:3.0.14 zsh -c 'sleep infinity'
+podman pull quay.io/rht-labs/stack-tl500:3.0.16
+podman run -d --name stack quay.io/rht-labs/stack-tl500:3.0.16 zsh -c 'sleep infinity'
 podman exec -it stack zsh
 
 git clone https://github.com/rht-labs/tech-exercise.git
@@ -88,9 +120,12 @@ cd tech-exercise && cd tests
 - [X] waits on resources .. e.g for nexus, jenkins pods - ho do we sync this ? hardcode between tests with a test markdown ?
 - [X] patch rundoc for upto 4 whitespace in markdown -> html
 - [X] remove branch for tests development uj
+
 ```bash
 # FIXME test branch
 --set source_ref=tests
 ```
+
 - [X] gitlab delete all other api patoken's when creating a new one
 - [X] add a tidy function to delete all git resources at end of tests
+- [X] parametrize git repository and branch

--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,3 +1,3 @@
-FROM quay.io/rht-labs/stack-tl500:3.0.13
+FROM quay.io/rht-labs/stack-tl500:3.0.16
 COPY run.sh /usr/local/bin
 ENTRYPOINT [ "/usr/local/bin/run.sh" ]

--- a/tests/container/run.sh
+++ b/tests/container/run.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+# capture en vars, othwerwise use default values
+TECH_EXERCISE_REPO="${REPO:=https://github.com/rht-labs/tech-exercise.git}"
+TECH_EXERCISE_BRANCH="${BRANCH:=main}"
+
 # setup container user
 /usr/local/bin/entrypoint.sh
 
 # run the test suite
-git clone https://github.com/rht-labs/tech-exercise.git 2>&1
-cd tech-exercise && git checkout main && cd tests
+git clone "${TECH_EXERCISE_REPO}" 2>&1
+cd tech-exercise && git checkout "${TECH_EXERCISE_BRANCH} && cd tests
 
 # nuke and exit
 if [ ! -z "${NUKE_ONLY}" ]; then

--- a/tests/container/run.sh
+++ b/tests/container/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# capture en vars, othwerwise use default values
+# capture en vars, otherwise use default values
 TECH_EXERCISE_REPO="${REPO:=https://github.com/rht-labs/tech-exercise.git}"
 TECH_EXERCISE_BRANCH="${BRANCH:=main}"
 

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -99,26 +99,26 @@ gitlab_personal_access_token() {
     gitlabEncodedPassword=$(echo ${GITLAB_PASSWORD} | perl -MURI::Escape -ne 'chomp;print uri_escape($_)')
     # get csrf from login page
     gitlab_basic_auth_string="Basic $(echo -n ${GITLAB_USER}:${gitlabEncodedPassword} | base64)"
-    body_header=$(curl -L -s -H "Authorization: ${gitlab_basic_auth_string}" -c /tmp/cookies.txt -i "https://${GIT_SERVER}/users/sign_in")
+    body_header=$(curl -k -L -s -H "Authorization: ${gitlab_basic_auth_string}" -c /tmp/cookies.txt -i "https://${GIT_SERVER}/users/sign_in")
     csrf_token=$(echo $body_header | perl -ne 'print "$1\n" if /new_user.*?authenticity_token"[[:blank:]]value="(.+?)"/' | sed -n 1p)
     # login
-    curl -s -H "Authorization: ${gitlab_basic_auth_string}" -b /tmp/cookies.txt -c /tmp/cookies.txt -i "https://${GIT_SERVER}/users/auth/ldapmain/callback" \
+    curl -k -s -H "Authorization: ${gitlab_basic_auth_string}" -b /tmp/cookies.txt -c /tmp/cookies.txt -i "https://${GIT_SERVER}/users/auth/ldapmain/callback" \
                         --data "username=${GITLAB_USER}&password=${gitlabEncodedPassword}" \
                         --data-urlencode "authenticity_token=${csrf_token}" \
                         > /dev/null
     # generate personal access token form
-    body_header=$(curl -L -H "Authorization: ${gitlab_basic_auth_string}" -H 'user-agent: curl' -b /tmp/cookies.txt -i "https://${GIT_SERVER}/profile/personal_access_tokens" -s)
+    body_header=$(curl -k -L -H "Authorization: ${gitlab_basic_auth_string}" -H 'user-agent: curl' -b /tmp/cookies.txt -i "https://${GIT_SERVER}/profile/personal_access_tokens" -s)
     csrf_token=$(echo $body_header | perl -ne 'print "$1\n" if /authenticity_token"[[:blank:]]value="(.+?)"/' | sed -n 1p)
     # revoke them all 💀 !!
     revoke=$(echo $body_header | perl -nle 'print join " ", m/personal_access_tokens\/(\d+)/g;')
     if [ ! -z "$revoke" ]; then
         for x in $revoke; do
             echo "💀 Revoking $x ..."
-            curl -s -o /dev/null -L -b /tmp/cookies.txt -X POST "https://${GIT_SERVER}/profile/personal_access_tokens/$x/revoke" --data-urlencode "authenticity_token=${csrf_token}" --data-urlencode "_method=put"
+            curl -k -s -o /dev/null -L -b /tmp/cookies.txt -X POST "https://${GIT_SERVER}/profile/personal_access_tokens/$x/revoke" --data-urlencode "authenticity_token=${csrf_token}" --data-urlencode "_method=put"
         done
     fi
     # scrape the personal access token from the response
-    body_header=$(curl -s -L -H "Authorization: ${gitlab_basic_auth_string}" -b /tmp/cookies.txt "https://${GIT_SERVER}/profile/personal_access_tokens" \
+    body_header=$(curl -k -s -L -H "Authorization: ${gitlab_basic_auth_string}" -b /tmp/cookies.txt "https://${GIT_SERVER}/profile/personal_access_tokens" \
                         --data-urlencode "authenticity_token=${csrf_token}" \
                         --data 'personal_access_token[name]='"${GITLAB_USER}"'&personal_access_token[expires_at]=&personal_access_token[scopes][]=api')
     personal_access_token=$(echo $body_header | perl -ne 'print "$1\n" if /created-personal-access-token"[[:blank:]]value="(.+?)"/' | sed -n 1p)
@@ -195,7 +195,7 @@ gitlab_delete_group() {
     ret=1; i=0
     until [ $ret = "202" ]
     do
-        ret=$(curl -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X DELETE "https://${GIT_SERVER}/api/v4/groups/${group_id}")
+        ret=$(curl -k -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X DELETE "https://${GIT_SERVER}/api/v4/groups/${group_id}")
         echo "🧁 Waiting for 202 response to delete group ${TEAM_NAME}"
         sleep 5
         ((i=i+1))
@@ -219,7 +219,7 @@ gitlab_recreate_project() {
     ret=1; i=0
     until [ $ret = "202" -o $ret = "404" ]
     do
-        ret=$(curl -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X DELETE "https://${GIT_SERVER}/api/v4/projects/${TEAM_NAME}%2F${projectname}")
+        ret=$(curl -k -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X DELETE "https://${GIT_SERVER}/api/v4/projects/${TEAM_NAME}%2F${projectname}")
         echo "🧁 Waiting for 202 or 404 response to delete ${projectname}"
         sleep 5
         ((i=i+1))
@@ -232,7 +232,7 @@ gitlab_recreate_project() {
     ret=1; i=0
     until [ $ret = "201" ]
     do
-        ret=$(curl -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X POST "https://${GIT_SERVER}/api/v4/projects" --data "name=${projectname}&visibility=public&namespace_id=${group_id}")
+        ret=$(curl -k -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X POST "https://${GIT_SERVER}/api/v4/projects" --data "name=${projectname}&visibility=public&namespace_id=${group_id}")
         echo "🍻 Waiting for 201 response to create ${projectname}"
         sleep 5
         ((i=i+1))
@@ -256,7 +256,7 @@ gitlab_delete_project() {
     ret=1; i=0
     until [ $ret = "202" -o $ret = "404" ]
     do
-        ret=$(curl -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X DELETE "https://${GIT_SERVER}/api/v4/projects/${TEAM_NAME}%2F${projectname}")
+        ret=$(curl -k -s -o /dev/null -w %{http_code} -k -H "PRIVATE-TOKEN: ${personal_access_token}" -X DELETE "https://${GIT_SERVER}/api/v4/projects/${TEAM_NAME}%2F${projectname}")
         echo "🧁 Waiting for 202 or 404 response to delete ${projectname}"
         sleep 5
         ((i=i+1))
@@ -407,7 +407,7 @@ wait_for_nexus_server() {
 wait_for_pet_battle_api() {
     local i=0
     HOST=https://$(oc -n ${TEAM_NAME}-test get route pet-battle-api --template='{{ .spec.host }}')
-    until [ $(curl -s -o /dev/null -w %{http_code} ${HOST}) = "200" ]
+    until [ $(curl -k -s -o /dev/null -w %{http_code} ${HOST}) = "200" ]
     do
         echo "🥯 Waiting for 200 response from ${HOST}"
         sleep 10
@@ -423,7 +423,7 @@ wait_for_pet_battle_api() {
 wait_for_pet_battle() {
     local i=0
     HOST=https://$(oc -n ${TEAM_NAME}-test get route pet-battle --template='{{ .spec.host }}')
-    until [ $(curl -s -o /dev/null -w %{http_code} ${HOST}) = "200" ]
+    until [ $(curl -k -s -o /dev/null -w %{http_code} ${HOST}) = "200" ]
     do
         echo "🧅 Waiting for 200 response from ${HOST}"
         sleep 10


### PR DESCRIPTION
Basically this PR makes two things:

* Make curl commands insecure, based on the same reasoning of this other PR: https://github.com/rht-labs/enablement-framework/pull/138 (Basically it is the interim solution for GLS envs untille we find a better approach)
* Be able to run the tests agains an specific repository and branch. Current default repo and and branch remain untouched, unless the env vars `REPO` and `BRANCH` are set. 