### PR TITLE
Update the version of Jenkins Helm chart

### DIFF
--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -35,7 +35,7 @@ applications:
     enabled: true
     source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/jenkins
-    source_ref: "jenkins-1.0.6"
+    source_ref: "jenkins-1.0.10"
     values:
       buildconfigs:
         # Jenkins S2I from Red Hat Labs


### PR DESCRIPTION
... to get rid of SSL verification on GIT plugin