### PR TITLE
Add bash code md tag on 4a-jenkins.md

### DIFF
--- a/docs/3-revenge-of-the-automated-testing/4a-jenkins.md
+++ b/docs/3-revenge-of-the-automated-testing/4a-jenkins.md
@@ -34,7 +34,7 @@
 5. Push our changes to the repo to trigger a new build
 
 
-    ```
+    ```bash
     cd /projects/pet-battle
     git add .
     git commit -m "💅 ADD - linting to the pipeline 💅"


### PR DESCRIPTION
As you can see in https://rht-labs.com/tech-exercise/#/3-revenge-of-the-automated-testing/4a-jenkins step 5) the bash code block is not rendered correctly because it has not the bash md tag. This fix adds that tag for getting a correct render.