### PR TITLE
Fix pet-battle-api version bump on 2-create-alerts.md

### DIFF
--- a/docs/4-return-of-the-monitoring/2-create-alerts.md
+++ b/docs/4-return-of-the-monitoring/2-create-alerts.md
@@ -52,14 +52,14 @@
 
     ```xml
         <artifactId>pet-battle-api</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     ```
 
     You can also run this bit of code to do the replacement if you are feeling uber lazy!
 
     ```bash#test
     cd /projects/pet-battle-api
-    mvn -ntp versions:set -DnewVersion=1.3.1
+    mvn -ntp versions:set -DnewVersion=1.3.2
     ```
 
 5. Now push the changes into the repo:


### PR DESCRIPTION
The docs/4-return-of-the-monitoring/2-create-alerts.md step 5) lab is not working because the pet-battle-api version bump is not done correctly. The instructions teach the student to bump to version 1.3.1, but this is the current version of the pet-battle-api chart at that point (the previous docs/3-revenge-of-the-automated-testing/5b-tekton.md lab bumps to that version, 1.3.1). 

Because of this incorrect version bump, the PrometheusRule object in ArgoCD is not updated with the new alerts rules used on the lab as PetBattleMongoDBDiskUsage, the lab alert is not triggered and the lab fails.

The solution proposed in this PR is to perform a correct pet-battle-api chart version bump to `1.3.2` . I have tested in my GLS TL500 lab that this solution fixes the problem.  Many thanks in advance for the review @eformat .