### PR TITLE
Update cosign handling

### DIFF
--- a/docs/3-revenge-of-the-automated-testing/8-image-signing.md
+++ b/docs/3-revenge-of-the-automated-testing/8-image-signing.md
@@ -12,13 +12,13 @@
 
     ```bash
     cd /tmp
-    cosign generate-key-pair k8s://${TEAM_NAME}-ci-cd/${TEAM_NAME}-cosign --allow-insecure-registry
+    cosign generate-key-pair k8s://${TEAM_NAME}-ci-cd/${TEAM_NAME}-cosign 
     ```
 
     You should get an output like this:
     <div class="highlight" style="background: #f7f7f7">
     <pre><code class="language-bash">
-    $ cosign generate-key-pair k8s://${TEAM_NAME}-ci-cd/${TEAM_NAME}-cosign --allow-insecure-registry
+    $ cosign generate-key-pair k8s://${TEAM_NAME}-ci-cd/${TEAM_NAME}-cosign 
     Enter password for private key:
     Enter again:
     Successfully created secret cosign in namespace <TEAM_NAME>-ci-cd

--- a/docs/3-revenge-of-the-automated-testing/8b-tekton.md
+++ b/docs/3-revenge-of-the-automated-testing/8b-tekton.md
@@ -25,7 +25,7 @@
         - name: COSIGN_VERSION
           type: string
           description: Version of cosign CLI
-          default: 1.0.0
+          default: 1.7.2
         - name: WORK_DIRECTORY
           description: Directory to start build in (handle multiple branches)
           type: string


### PR DESCRIPTION
A bugfix for: https://github.com/rht-labs/tech-exercise/issues/242
* Remove --allow-insecure-registry flag for `cosign generate` subcommond since it's not supported in that usecase

* Bump version of cosign set for Tekton pipeline