### PR TITLE
🦆 update chart + image versions. adds OCP4.12 support 🦆

### DIFF
--- a/docs/1-the-manual-menace/4-extend-uj.md
+++ b/docs/1-the-manual-menace/4-extend-uj.md
@@ -37,7 +37,7 @@ git pull
         enabled: true
         source: https://redhat-cop.github.io/helm-charts
         chart_name: sonatype-nexus
-        source_ref: "1.1.10"
+        source_ref: "1.1.11"
         values:
           includeRHRepositories: false
           service:
@@ -48,7 +48,7 @@ git pull
 
     ```bash#test
     if [[ $(yq e '.applications[] | select(.name=="nexus") | length' /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml) < 1 ]]; then
-        yq e '.applications += {"name": "nexus","enabled": true,"source": "https://redhat-cop.github.io/helm-charts","chart_name": "sonatype-nexus","source_ref": "1.1.10","values":{"includeRHRepositories": false,"service": {"name": "nexus"}}}' -i /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml
+        yq e '.applications += {"name": "nexus","enabled": true,"source": "https://redhat-cop.github.io/helm-charts","chart_name": "sonatype-nexus","source_ref": "1.1.11","values":{"includeRHRepositories": false,"service": {"name": "nexus"}}}' -i /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml
     fi
     ```
 

--- a/docs/3-revenge-of-the-automated-testing/1-sonar-scanning.md
+++ b/docs/3-revenge-of-the-automated-testing/1-sonar-scanning.md
@@ -97,15 +97,15 @@
         enabled: true
         source: https://redhat-cop.github.io/helm-charts
         chart_name: sonarqube
-        source_ref: "0.1.0"
+        source_ref: "0.1.2"
         values:
           account:
             existingSecret: sonarqube-auth
           initContainers: true
           plugins:
             install:
-              - https://github.com/checkstyle/sonar-checkstyle/releases/download/9.2/checkstyle-sonar-plugin-9.2.jar
-              - https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.8/sonar-dependency-check-plugin-2.0.8.jar
+              - https://github.com/checkstyle/sonar-checkstyle/releases/download/10.9.3/checkstyle-sonar-plugin-10.9.3.jar
+              - https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/3.1.0/sonar-dependency-check-plugin-3.1.0.jar
     ```
 
 6. Git add, commit, push your changes (GITOPS WOOOO 🪄🪄). On ArgoCD you'll see it come alive.

--- a/docs/3-revenge-of-the-automated-testing/1-sonar-scanning.md
+++ b/docs/3-revenge-of-the-automated-testing/1-sonar-scanning.md
@@ -97,7 +97,7 @@
         enabled: true
         source: https://redhat-cop.github.io/helm-charts
         chart_name: sonarqube
-        source_ref: "0.1.2"
+        source_ref: "0.1.3"
         values:
           account:
             existingSecret: sonarqube-auth

--- a/docs/3-revenge-of-the-automated-testing/2b-tekton.md
+++ b/docs/3-revenge-of-the-automated-testing/2b-tekton.md
@@ -123,7 +123,7 @@
         - name: IMAGE
           description: the image to use to upload results
           type: string
-          default: "quay.io/openshift/origin-cli:4.9"
+          default: "quay.io/openshift/origin-cli:4.12"
         - name: WORK_DIRECTORY
           description: Directory to start build in (handle multiple branches)
           type: string

--- a/docs/3-revenge-of-the-automated-testing/5b-tekton.md
+++ b/docs/3-revenge-of-the-automated-testing/5b-tekton.md
@@ -156,14 +156,14 @@ Let's run through a scenario where we break/fix the build with **kube-linter**.
 
     ```xml
         <artifactId>pet-battle-api</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     ```
 
     You can also run this bit of code to do the replacement if you are feeling uber lazy!
 
     ```bash#test
     cd /projects/pet-battle-api
-    mvn -ntp versions:set -DnewVersion=1.3.1
+    mvn -ntp versions:set -DnewVersion=1.3.2
     ```
 
 8. We can check the **kube-linter** command again and check these changes in:

--- a/docs/3-revenge-of-the-automated-testing/7b-tekton.md
+++ b/docs/3-revenge-of-the-automated-testing/7b-tekton.md
@@ -221,7 +221,7 @@ Let's run through a scenario where we break/fix the build using a build policy v
 6. Remove the `EXPOSE 22` from the `Dockerfile.jvm` and check it in to make the build pass.
 
     ```bash
-    cd /project/pet-battle-api
+    cd /projects/pet-battle-api
     git add .
     git commit -m  "🐧 FIX - Security violation, remove port 22 exposure 🐧"
     git push

--- a/docs/3-revenge-of-the-automated-testing/8a-jenkins.md
+++ b/docs/3-revenge-of-the-automated-testing/8a-jenkins.md
@@ -33,7 +33,7 @@
                     script {
                         sh '''
                         oc registry login
-                        cosign sign -key k8s://${TEAM_NAME}-ci-cd/${TEAM_NAME}-cosign `oc registry info`/${DESTINATION_NAMESPACE}/${APP_NAME}:${VERSION} --allow-insecure-registry
+                        cosign sign --key k8s://${TEAM_NAME}-ci-cd/${TEAM_NAME}-cosign `oc registry info`/${DESTINATION_NAMESPACE}/${APP_NAME}:${VERSION} --allow-insecure-registry
                         '''
                     }
                 }

--- a/docs/3-revenge-of-the-automated-testing/8b-tekton.md
+++ b/docs/3-revenge-of-the-automated-testing/8b-tekton.md
@@ -25,13 +25,13 @@
         - name: COSIGN_VERSION
           type: string
           description: Version of cosign CLI
-          default: 1.7.2
+          default: 2.0.2
         - name: WORK_DIRECTORY
           description: Directory to start build in (handle multiple branches)
           type: string
       steps:
         - name: image-signing
-          image: quay.io/openshift/origin-cli:4.9
+          image: quay.io/openshift/origin-cli:4.12
           workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
           script: |
             #!/usr/bin/env bash
@@ -39,7 +39,7 @@
             chmod -R 775 /tmp/cosign
 
             oc registry login
-            /tmp/cosign sign -key k8s://$(params.TEAM_NAME)-ci-cd/$(params.TEAM_NAME)-cosign `oc registry info`/$(params.TEAM_NAME)-test/$(params.APPLICATION_NAME):$(params.VERSION) --allow-insecure-registry
+            /tmp/cosign sign --key k8s://$(params.TEAM_NAME)-ci-cd/$(params.TEAM_NAME)-cosign `oc registry info`/$(params.TEAM_NAME)-test/$(params.APPLICATION_NAME):$(params.VERSION) --allow-insecure-registry
     EOF
     ```
 

--- a/docs/3-revenge-of-the-automated-testing/9b-tekton.md
+++ b/docs/3-revenge-of-the-automated-testing/9b-tekton.md
@@ -63,7 +63,7 @@
           type: string
       steps:
         - name: load-testing
-          image: quay.io/centos7/python-38-centos7:latest
+          image: registry.access.redhat.com/ubi9/python-39:latest
           workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
           script: |
             #!/usr/bin/env bash

--- a/docs/4-return-of-the-monitoring/2-create-alerts.md
+++ b/docs/4-return-of-the-monitoring/2-create-alerts.md
@@ -52,14 +52,14 @@
 
     ```xml
         <artifactId>pet-battle-api</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
     ```
 
     You can also run this bit of code to do the replacement if you are feeling uber lazy!
 
     ```bash#test
     cd /projects/pet-battle-api
-    mvn -ntp versions:set -DnewVersion=1.3.2
+    mvn -ntp versions:set -DnewVersion=1.3.3
     ```
 
 5. Now push the changes into the repo:

--- a/docs/5-the-deployments-strike-back/1-autoscaling.md
+++ b/docs/5-the-deployments-strike-back/1-autoscaling.md
@@ -81,12 +81,12 @@
     Then, using the `k6` binary, run the load test using more than one virtual user and a defined duration.
 
     ```bash
-    k6 run --insecure-skip-tls-verify --vus 100 --duration 30s /tmp/load.js 
+    k6 run --insecure-skip-tls-verify --vus 100 --duration 300s /tmp/load.js 
     ```
 
     Where:
     * --vus: Number of virtual users (VUs) to run concurrently (100)
-    * --duration: Test duration limit (30s)
+    * --duration: Test duration limit (300s)
 
 6. While this is running, we should see in OpenShift land the autoscaler is kickin in and spinnin gup additional pods. If you navigate to the pet-battle-api deployment, you should see the replica count has jumped.
 

--- a/tekton/templates/tasks/bake-image.yaml
+++ b/tekton/templates/tasks/bake-image.yaml
@@ -34,7 +34,7 @@ spec:
   steps:
     - name: package-app #better name for it
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
-      image: quay.io/openshift/origin-cli:4.9
+      image: quay.io/openshift/origin-cli:4.12
       script: |
         #!/bin/sh
         mv Dockerfile.jvm  Dockerfile
@@ -42,14 +42,14 @@ spec:
         curl -v -f -u $(params.STATIC_REPO_USERNAME):$(params.STATIC_REPO_PASSWORD) $(params.STATIC_REPO) --upload-file $(params.APPLICATION_NAME)-$(params.VERSION).tar.gz
     - name: openshift-build
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
-      image: quay.io/openshift/origin-cli:4.9
+      image: quay.io/openshift/origin-cli:4.12
       script: |
         #!/bin/sh
         oc new-build --binary --name=$(params.APPLICATION_NAME) -l app=$(params.APPLICATION_NAME) -l app.kubernetes.io/name=$(params.APPLICATION_NAME) --strategy=docker || rc=$?
         oc start-build $(params.APPLICATION_NAME) --from-archive=$(params.APPLICATION_NAME)-$(params.VERSION).tar.gz --follow --wait
     - name: tag-image
       workingDir: $(workspaces.output.path)
-      image: quay.io/openshift/origin-cli:4.9
+      image: quay.io/openshift/origin-cli:4.12
       script: |
         #!/bin/sh
         oc tag $(params.TEAM_NAME)-ci-cd/$(params.APPLICATION_NAME):latest $(params.TEAM_NAME)-test/$(params.APPLICATION_NAME):$(params.VERSION)

--- a/tekton/templates/tasks/verify.yaml
+++ b/tekton/templates/tasks/verify.yaml
@@ -31,7 +31,7 @@ spec:
   steps:
     - name: verify
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
-      image: quay.io/openshift/origin-cli:4.9
+      image: quay.io/openshift/origin-cli:4.12
       script: |
         #!/bin/sh
         # verify the deployment by checking the VERSION against PREVIOUS_VERSION

--- a/tests/doc-regression-test-files/good-4-extend-uj.json
+++ b/tests/doc-regression-test-files/good-4-extend-uj.json
@@ -15,12 +15,12 @@
             ]
         },
         {
-            "code": "    if [[ $(yq e '.applications[] | select(.name==\"nexus\") | length' /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml) < 1 ]]; then\n        yq e '.applications += {\"name\": \"nexus\",\"enabled\": true,\"source\": \"https://redhat-cop.github.io/helm-charts\",\"chart_name\": \"sonatype-nexus\",\"source_ref\": \"1.1.10\",\"values\":{\"includeRHRepositories\": false,\"service\": {\"name\": \"nexus\"}}}' -i /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml\n    fi\n",
+            "code": "    if [[ $(yq e '.applications[] | select(.name==\"nexus\") | length' /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml) < 1 ]]; then\n        yq e '.applications += {\"name\": \"nexus\",\"enabled\": true,\"source\": \"https://redhat-cop.github.io/helm-charts\",\"chart_name\": \"sonatype-nexus\",\"source_ref\": \"1.1.11\",\"values\":{\"includeRHRepositories\": false,\"service\": {\"name\": \"nexus\"}}}' -i /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml\n    fi\n",
             "interpreter": "bash",
             "runs": [
                 {
                     "retcode": 0,
-                    "user_code": "    if [[ $(yq e '.applications[] | select(.name==\"nexus\") | length' /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml) < 1 ]]; then\n        yq e '.applications += {\"name\": \"nexus\",\"enabled\": true,\"source\": \"https://redhat-cop.github.io/helm-charts\",\"chart_name\": \"sonatype-nexus\",\"source_ref\": \"1.1.10\",\"values\":{\"includeRHRepositories\": false,\"service\": {\"name\": \"nexus\"}}}' -i /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml\n    fi\n"
+                    "user_code": "    if [[ $(yq e '.applications[] | select(.name==\"nexus\") | length' /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml) < 1 ]]; then\n        yq e '.applications += {\"name\": \"nexus\",\"enabled\": true,\"source\": \"https://redhat-cop.github.io/helm-charts\",\"chart_name\": \"sonatype-nexus\",\"source_ref\": \"1.1.11\",\"values\":{\"includeRHRepositories\": false,\"service\": {\"name\": \"nexus\"}}}' -i /projects/tech-exercise/ubiquitous-journey/values-tooling.yaml\n    fi\n"
                 }
             ],
             "tags": [

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -35,7 +35,7 @@ applications:
     enabled: true
     source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/jenkins
-    source_ref: "jenkins-1.0.6"
+    source_ref: "jenkins-1.0.9"
     values:
       buildconfigs:
         # Jenkins S2I from Red Hat Labs


### PR DESCRIPTION
- updates charts to latest tool versions
- runs on v4.12 OpenShift now as well

I have done a full run through OK from start to finish for TL500 OK. 

Links with this PR:
https://github.com/rht-labs/enablement-framework/pull/163