### PR TITLE
WIP: 🐂 che-theia is removed as supported IDE 🐂

### DIFF
--- a/docs/config/all.json
+++ b/docs/config/all.json
@@ -1,4 +1,4 @@
 {
     "devfile": "https://raw.githubusercontent.com/rht-labs/enablement-framework/main/codereadyworkspaces/tl500-devfile.yaml",
-    "devfile411": "https://raw.githubusercontent.com/rht-labs/enablement-framework/main/codereadyworkspaces/tl500-devfile-v2.yaml?che-editor=eclipse/che-theia/latest"
+    "devfile411": "https://raw.githubusercontent.com/rht-labs/enablement-framework/main/codereadyworkspaces/tl500-devfile-v2.yaml?che-editor=che-incubator/che-code/latest"
 }


### PR DESCRIPTION
Che-Theia is removed as a supported IDE (see https://issues.redhat.com/browse/CRW-3663)  So the current OCP 4.11+ workspace link gets 404 error. We need to switch VS Code but that requires changing the screenshots to open terminal etc as well. Therefore I marked the PR as WIP for now. My question @eformat is, should we go only for 4.11+ in the docs in main? I think that'd be better as we have now have tags.