### PR TITLE
🦙 FIX - version of the ocp base for demo system 🦙

### DIFF
--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -46,7 +46,7 @@ applications:
           source_context_dir: '/'
           builder_image_kind: "DockerImage"
           builder_image_name: quay.io/openshift/origin-jenkins
-          builder_image_tag: "4.14"
+          builder_image_tag: "4.12"
         # Jenkins agents for running builds etc
         # default names, versions, repo and paths set on the template
         - name: jenkins-agent-npm


### PR DESCRIPTION
@tdbeattie is doing a run of the course using upstream this week. They're using a 4.12 cluster so this will need to be changed for the jenkins exercise to work  as per fixes in here 
https://github.com/rht-labs/s2i-config-jenkins/pull/47