### PR TITLE
:bug: Fix detected dubious ownership in git repo

### DIFF
--- a/tekton/templates/tasks/deploy.yaml
+++ b/tekton/templates/tasks/deploy.yaml
@@ -61,6 +61,7 @@ spec:
         git config --global user.email "tekton@rht-labs.bot.com"
         git config --global user.name "🐈 Tekton 🐈"
         git config --global push.default simple
+        git config --global --add safe.directory '*'
         git checkout main
         git add $(params.DEPLOY_ENVIRONMENT)/values.yaml
         git commit -m "🚀 AUTOMATED COMMIT - Deployment of $(params.APPLICATION_NAME) at version $(params.VERSION) 🚀" || rc=$?


### PR DESCRIPTION
This PR fixes the #278 issue.

I would like a double check from my colleages @ckavili @eformat and @springdo .

Maybe the cause is related to the `git config --global --add safe.directory /workspace/output` command executed by the `git-clone` cluster task. I can't remember that command in previous versions or executions of this pipeline.

Ideas? Comments?