### PR TITLE
correct jenkins/tekton test links

### DIFF
--- a/docs/3-revenge-of-the-automated-testing/10-load-testing.md
+++ b/docs/3-revenge-of-the-automated-testing/10-load-testing.md
@@ -11,4 +11,4 @@
 | 🐈‍⬛ **Jenkins Group** 🐈‍⬛  |  🐅 **Tekton Group** 🐅 |
 |-----------------------|----------------------------|
 | * Add a load test task to our pipeline | * Add a load test task to our pipeline |
-| <span style="color:blue;">[jenkins](3-revenge-of-the-automated-testing/9a-jenkins.md)</span> | <span style="color:blue;">[tekton](3-revenge-of-the-automated-testing/9b-tekton.md)</span> |
+| <span style="color:blue;">[jenkins](3-revenge-of-the-automated-testing/10a-jenkins.md)</span> | <span style="color:blue;">[tekton](3-revenge-of-the-automated-testing/10b-tekton.md)</span> |

--- a/docs/3-revenge-of-the-automated-testing/9-sbom.md
+++ b/docs/3-revenge-of-the-automated-testing/9-sbom.md
@@ -88,4 +88,4 @@ _This step makes more sense when you use an external image registry and share im
 |-----------------------|----------------------------|
 | * Generate SBOM with Syft in our pipeline| * Generate SBOM with Syft in our pipeline |
 | * Sign, attach and attest SBOM | * Sign, attach and attest SBOM |
-| <span style="color:blue;">[jenkins](3-revenge-of-the-automated-testing/11a-jenkins.md)</span> | <span style="color:blue;">[tekton](3-revenge-of-the-automated-testing/11b-tekton.md)</span> |
+| <span style="color:blue;">[jenkins](3-revenge-of-the-automated-testing/9a-jenkins.md)</span> | <span style="color:blue;">[tekton](3-revenge-of-the-automated-testing/9b-tekton.md)</span> |


### PR DESCRIPTION
The load test and generate SBOM pages had broken links to the jenkins/tekton pages