### PR TITLE
:seedling: Fix broken link

### DIFF
--- a/docs/3-revenge-of-the-automated-testing/README.md
+++ b/docs/3-revenge-of-the-automated-testing/README.md
@@ -12,7 +12,7 @@ There are lots of things we can do under the heading of `Quality Gates`, so deci
 
 ![team-kanban](images/team-kanban.jpg)
 
-To onboard a new group in your team, follow this [guide](98-a-new-group/README.md).
+To onboard a new group in your team, follow this <span style="color:blue;">[guide](2-attack-of-the-pipelines/3c-create-new-group.md)</span>.
 
 ## 🖼️ Big Picture
 


### PR DESCRIPTION
Fix broken link to create a second group. The original link produces a 404 error.