### PR TITLE
Bump Jenkins helm chart

### DIFF
--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -35,7 +35,7 @@ applications:
     enabled: true
     source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/jenkins
-    source_ref: "jenkins-1.0.10"
+    source_ref: "jenkins-1.0.13"
     values:
       buildconfigs:
         # Jenkins S2I from Red Hat Labs


### PR DESCRIPTION
This runs Jenkins as a Deployment instead of deprecated DeploymentConfig

Ref: https://github.com/redhat-cop/helm-charts/pull/613