### PR TITLE
Updated Pet Battle API Chart version

### DIFF
--- a/docs/2-attack-of-the-pipelines/2-app-of-apps.md
+++ b/docs/2-attack-of-the-pipelines/2-app-of-apps.md
@@ -90,7 +90,7 @@ We deploy each of our applications using an Argo CD `application` definition. We
         enabled: true
         source: https://petbattle.github.io/helm-charts  # http://nexus:8081/repository/helm-charts
         chart_name: pet-battle-api
-        source_ref: 1.2.1 # helm chart version
+        source_ref: 1.5.0 # helm chart version
         values:
           image_name: pet-battle-api
           image_version: latest # container image version


### PR DESCRIPTION
Updated Pet Battle API Chart version to deploy the latest version of MongoDB and being able to start the petbattle-api pod correctly.