### PR TITLE
Fix/gitlab pat

### DIFF
--- a/docs/1-the-manual-menace/3-ubiquitous-journey.md
+++ b/docs/1-the-manual-menace/3-ubiquitous-journey.md
@@ -83,8 +83,6 @@ All of these traits lead to one outcome - the ability to build and release quali
     git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
     ```
 
-    Use the `GITLAB_PAT` from above when you are prompted for the password (this will be cached)
-
     ```bash#test
     cd /projects/tech-exercise
     git add .

--- a/docs/1-the-manual-menace/3-ubiquitous-journey.md
+++ b/docs/1-the-manual-menace/3-ubiquitous-journey.md
@@ -80,7 +80,7 @@ All of these traits lead to one outcome - the ability to build and release quali
 
     ```bash#test
     cd /projects/tech-exercise
-    git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
+    git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
     ```
 
     Use the `GITLAB_PAT` from above when you are prompted for the password (this will be cached)


### PR DESCRIPTION
The username and password prompt is easily missed at the top in the Workspace. Also it may not be intuitive to set the GitLab PAT then be asked for username and password and use the PAT as password as hinted afterwards. This change would persist the creds and remove potential confusions for the students. Security wise I'm not sure, but since we persist the envs anyway, there wouldn't be a difference.