### PR TITLE
Adjust GitLab PAT usage

### DIFF
--- a/docs/1-the-manual-menace/3-ubiquitous-journey.md
+++ b/docs/1-the-manual-menace/3-ubiquitous-journey.md
@@ -83,8 +83,6 @@ All of these traits lead to one outcome - the ability to build and release quali
     git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
     ```
 
-    Use the `GITLAB_PAT` from above when you are prompted for the password (this will be cached)
-
     ```bash#test
     cd /projects/tech-exercise
     git add .

--- a/docs/1-the-manual-menace/3-ubiquitous-journey.md
+++ b/docs/1-the-manual-menace/3-ubiquitous-journey.md
@@ -67,8 +67,9 @@ All of these traits lead to one outcome - the ability to build and release quali
     echo $GITLAB_PAT
     ```
     
-    ..and lets persist it for now:
+    ..and lets persist your Username and Token for now:
     ```bash
+    echo "export GITLAB_USER=${GITLAB_USER}"  | tee -a ~/.bashrc -a ~/.zshrc
     echo "export GITLAB_PAT=${GITLAB_PAT}"  | tee -a ~/.bashrc -a ~/.zshrc
     ```
 

--- a/docs/1-the-manual-menace/3-ubiquitous-journey.md
+++ b/docs/1-the-manual-menace/3-ubiquitous-journey.md
@@ -80,7 +80,7 @@ All of these traits lead to one outcome - the ability to build and release quali
 
     ```bash#test
     cd /projects/tech-exercise
-    git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
+    git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
     ```
 
     Use the `GITLAB_PAT` from above when you are prompted for the password (this will be cached)

--- a/docs/1-the-manual-menace/4-extend-uj.md
+++ b/docs/1-the-manual-menace/4-extend-uj.md
@@ -7,7 +7,7 @@ Now, we have our projects, necessary rolebindings and Jenkins up and running. We
 
 ```bash
 cd /projects/tech-exercise
-git remote set-url origin https://<GIT_SERVER>/<TEAM_NAME>/tech-exercise.git
+git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
 git pull
 ```
 

--- a/docs/1-the-manual-menace/5-this-is-gitops.md
+++ b/docs/1-the-manual-menace/5-this-is-gitops.md
@@ -7,7 +7,7 @@
 
 ```bash
 cd /projects/tech-exercise
-git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
+git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
 git pull
 ```
 

--- a/docs/2-attack-of-the-pipelines/1-sealed-secrets.md
+++ b/docs/2-attack-of-the-pipelines/1-sealed-secrets.md
@@ -10,7 +10,7 @@ Sealed Secrets allows us to _seal_ Kubernetes secrets by using a utility called 
 
 ```bash
 cd /projects/tech-exercise
-git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
+git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
 git pull
 ```
 

--- a/docs/2-attack-of-the-pipelines/3-the-pipelines.md
+++ b/docs/2-attack-of-the-pipelines/3-the-pipelines.md
@@ -17,7 +17,7 @@ Why creating pipelines:
 
 ```bash
 cd /projects/tech-exercise
-git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
+git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
 git pull
 ```
 

--- a/docs/2-attack-of-the-pipelines/3a-jenkins.md
+++ b/docs/2-attack-of-the-pipelines/3a-jenkins.md
@@ -39,7 +39,7 @@ git push
     ```bash#test
     cd /projects
     git clone https://github.com/rht-labs/pet-battle.git && cd pet-battle
-    git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/pet-battle.git
+    git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/pet-battle.git
     git branch -M main
     git push -u origin main
     ```

--- a/docs/2-attack-of-the-pipelines/3b-tekton.md
+++ b/docs/2-attack-of-the-pipelines/3b-tekton.md
@@ -25,7 +25,7 @@ In this snippet of the pipeline used in this exercise, we define:
     ```bash#test
     cd /projects
     git clone https://github.com/rht-labs/pet-battle-api.git && cd pet-battle-api
-    git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/pet-battle-api.git
+    git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/pet-battle-api.git
     git branch -M main
     git push -u origin main
     ```

--- a/docs/2-attack-of-the-pipelines/3c-create-new-group.md
+++ b/docs/2-attack-of-the-pipelines/3c-create-new-group.md
@@ -103,7 +103,7 @@ team will be easy following the next instructions.
 
     ```bash#test
     cd /projects/tech-exercise
-    git remote set-url origin https://${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
+    git remote set-url origin https://${GITLAB_USER}:${GITLAB_PAT}@${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
     git pull
     ```
 


### PR DESCRIPTION
The username and password prompt is easily missed at the top in the Workspace. Also it may not be intuitive to set the GitLab PAT then be asked for username and password and use the PAT as password as hinted afterwards. This change would persist the creds and remove potential confusions for the students. Security wise I'm not sure, but since we persist the envs anyway, there wouldn't be a difference.