### PR TITLE
Declare repository definition as secrets

### DIFF
--- a/docs/1-the-manual-menace/1-the-basics.md
+++ b/docs/1-the-manual-menace/1-the-basics.md
@@ -32,10 +32,9 @@
     echo export CLUSTER_DOMAIN="<CLUSTER_DOMAIN>" | tee -a ~/.bashrc -a ~/.zshrc
     ```
 
-6. Add the `GIT_SERVER` to the environment:
+6. Add the `GIT_SERVER` to the environment (Routes available in `tl500-gitlab` namespace):
 
     ```bash#test
-    # Check routes in tl500-gitlab namespace
     echo export GIT_SERVER="<GIT_SERVER>" | tee -a ~/.bashrc -a ~/.zshrc
     ```
 

--- a/docs/1-the-manual-menace/2-argocd.md
+++ b/docs/1-the-manual-menace/2-argocd.md
@@ -65,27 +65,12 @@ When something is seen as not matching the desired state in Git, an application 
 
 2. Let's perform a basic install of ArgoCD. Using most of the defaults defined on the chart is sufficient for our use case.
 
-    We're also going to configure ArgoCD to be allowed to pull from our git repository using a secret 🔐.
-
-    Configure our ArgoCD instance with a secret in our <TEAM_NAME>-ci-cd namespace by creating a small bit of yaml 😋:
-
     ```bash#test
     cat << EOF > /projects/tech-exercise/argocd-values.yaml
     ignoreHelmHooks: true
     operator: []
     namespaces:
       - ${TEAM_NAME}-ci-cd
-    argocd_cr:
-      initialRepositories: |
-        - url: https://${GIT_SERVER}/${TEAM_NAME}/tech-exercise.git
-          type: git
-          passwordSecret:
-            key: password
-            name: git-auth
-          usernameSecret:
-            key: username
-            name: git-auth
-          insecure: true
     EOF
     ```
 

--- a/docs/1-the-manual-menace/3-ubiquitous-journey.md
+++ b/docs/1-the-manual-menace/3-ubiquitous-journey.md
@@ -176,9 +176,7 @@ All of these traits lead to one outcome - the ability to build and release quali
           credential.sync.jenkins.openshift.io: "true"
         name: git-auth
     EOF
-    ```
 
-    ```bash#test
     cat <<EOF | oc apply -n ${TEAM_NAME}-ci-cd -f -
       apiVersion: v1
       kind: Secret


### PR DESCRIPTION
This PR improves the usage of the definition of the repositories from the `ArgoCD` chapter to the `UJ` one. Deploying ArgoCD in the first exercise does not require to declare any reference to the `tech-exercises` repository, as it is not already created. The current definition of the ArgoCD operator[1], the creation of repositories only works the first execution, after that it is required to use the Argo CD Web UI or CLI.

As the `tech-exercise` is created in the next exercise, the documentation is extended to declare the definition of the required secrets (not as GitOps yet) to allow pull changes from it. It is easy create one using the `argocd.argoproj.io/secret-type: repository` label.

This PR simplify the deployment of ArgoCD in the first step, and define the usage of the repositories in the `UJ` exercise, where it makes sense.

[1] https://argocd-operator.readthedocs.io/en/stable/reference/argocd/#initial-repositories