### PR TITLE
[WIP]Resolve issue ArgoCD sync

### DIFF
--- a/tekton/templates/tasks/deploy.yaml
+++ b/tekton/templates/tasks/deploy.yaml
@@ -52,6 +52,7 @@ spec:
         yq eval -i .applications."$(params.APPLICATION_NAME)".values.image_repository=\"$(params.REPOSITORY)\" "$(params.DEPLOY_ENVIRONMENT)/values.yaml"
         yq eval -i .applications."$(params.APPLICATION_NAME)".values.image_version=\"$(params.VERSION)\" "$(params.DEPLOY_ENVIRONMENT)/values.yaml"
         yq eval -i .applications."$(params.APPLICATION_NAME)".values.image_namespace=\"$(params.TEAM_NAME)-$(params.DEPLOY_ENVIRONMENT)\" "$(params.DEPLOY_ENVIRONMENT)/values.yaml"
+        yq eval -i .applications."$(params.APPLICATION_NAME)".values.istag.enabled=false "$(params.DEPLOY_ENVIRONMENT)/values.yaml"
     - name: commit-changes
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
       image: quay.io/redhat-cop/ubi8-git:latest


### PR DESCRIPTION
There is an issue in ArgoCD when the image is promoted due to interal image registry usage:

`one or more objects failed to apply, reason: error when patching "/dev/shm/4130129997": ImageStream.image.openshift.io "pet-battle-api" is invalid: []: Internal error: imagestreams "pet-battle-api" is invalid: spec.tags[1.1.1].from.name: Invalid value: "image-registry.openshift-image-registry.svc:5000/redhat-test/pet-battle-api:1.1.1": must be of the form <tag>, <repo>:<tag>, <id>, or <repo>@<id> I have this error when I try to apply the following ImageStream:`

To solve it, in the promotion process, we change the `istag.enabled` property to remove the tags from the IS spec. In the promotion process the image is already tagged to the desired namespace, OpenShift will sync the tags automatically.